### PR TITLE
Model Uploader Recursive 

### DIFF
--- a/ModelUploader/Program.cs
+++ b/ModelUploader/Program.cs
@@ -23,11 +23,14 @@ namespace ModelUploader
 
         private static DigitalTwinsClient client;
         private static string modelPath;
+        private static bool deleteFirst;
 
         private class CliOptions
         {
             [Option('p', "path", Required = true, HelpText = "The path to the on-disk directory holding DTDL models.")]
             public string ModelPath { get; set; }
+            [Option('d', "deletefirst", Required = false, HelpText = "Specify if you want to delete the models first, by default is false")]
+            public bool DeleteFirst { get; set; }
         }
 
         static void Main(string[] args)
@@ -36,7 +39,9 @@ namespace ModelUploader
                    .WithParsed(o =>
                    {
                        modelPath = o.ModelPath;
-                   });
+                       deleteFirst = o.DeleteFirst;
+                   }                   
+                   );
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -94,19 +99,91 @@ namespace ModelUploader
             }
 
             Log.Ok($"Service client created – ready to go");
-
             try
             {
+                // Delete All Models first
+                if (deleteFirst)
+                    DeleteAllModels(1);                
+
                 EnumerationOptions options = new EnumerationOptions() { RecurseSubdirectories = true };
                 foreach (string file in Directory.EnumerateFiles(modelPath, "*.json", options))
                 {
                     StreamReader r = new StreamReader(file);
                     string dtdl = r.ReadToEnd();
                     r.Close();
-                    Response<ModelData[]> res = client.CreateModels(new List<string>() { dtdl });
-                    Log.Ok($"Model {file.Split("\\").Last()} created successfully!");
-                    foreach (ModelData md in res.Value)
-                        LogResponse(md.Model);
+
+                    try
+                    {
+                        Response<ModelData[]> res = client.CreateModels(new List<string>() { dtdl });
+                        Log.Ok($"Model {file.Split("\\").Last()} created successfully!");
+                        foreach (ModelData md in res.Value)
+                            LogResponse(md.Model);
+                    }
+                    catch (RequestFailedException e)
+                    {
+                        switch (e.Status)
+                        {
+                            case 409:
+                                // 409 is when the Model already exists - so just skip this model
+                                Log.Ok($"Model {file.Split("\\").Last()} already exists, skipped!");
+                                break;
+                            case 400:
+                                // Model could not be uploaded because of a dependency
+
+                                // find the missing dependency Model in the message
+                                int missingInterfaceIndexStart = e.Message.IndexOf("dtmi:");
+                                int missingInterfaceIndexEnd = e.Message.IndexOf(";1", missingInterfaceIndexStart);
+                                string missingInterface = e.Message.Substring(missingInterfaceIndexStart, missingInterfaceIndexEnd - missingInterfaceIndexStart);
+                                int missingPartIndex = missingInterface.LastIndexOf(":");
+                                missingInterface = missingInterface.Substring(missingPartIndex + 1);
+
+                                string[] missingFile = Directory.GetFiles(modelPath, missingInterface + ".json*", SearchOption.AllDirectories);
+                                if (missingFile[0] == null || missingFile[0] == "") break;
+
+                                // Read the contents of the file
+                                StreamReader r1 = new StreamReader(missingFile[0]);
+                                string dtdlDependency = r1.ReadToEnd();
+                                r1.Close();
+
+                                try
+                                {
+                                    // Upload the dependency model 
+                                    Response<ModelData[]> res1 = client.CreateModels(new List<string>() { dtdlDependency });
+                                    Log.Ok($"Dependent Model {file.Split("\\").Last()} created successfully! Now proceeeding with the original model");
+                                    foreach (ModelData md1 in res1.Value)
+                                        LogResponse(md1.Model);
+                                }
+                                catch (RequestFailedException e1)
+                                {
+                                    // dependency file didnt work, bail
+                                    Log.Error($"Dependency Model {missingFile[0].Split("\\").Last()}");
+                                    Log.Error($"Response {e1.Status}: {e1.Message}");
+
+                                    Log.Error($"Original Model We were trying for {file.Split("\\").Last()}");
+                                    return;
+                                }
+
+                                // now try the original file back again
+                                try
+                                {
+                                    Response<ModelData[]> res = client.CreateModels(new List<string>() { dtdl });
+                                    Log.Ok($"Model {file.Split("\\").Last()} created successfully!");
+                                    foreach (ModelData md in res.Value)
+                                        LogResponse(md.Model);
+                                }
+                                catch (RequestFailedException e2)
+                                {
+                                    // didnt work again, bail
+                                    Log.Error($"Model {file.Split("\\").Last()}");
+                                    Log.Error($"Response {e2.Status}: {e2.Message}");
+                                    return;
+                                }
+
+                                break;
+                            default:
+                                break;
+                        }
+                    }
                 }
             }
             catch (RequestFailedException e)
@@ -116,6 +193,35 @@ namespace ModelUploader
             catch (Exception ex)
             {
                 Log.Error($"Error: {ex.Message}");
+            }
+        }
+
+        private static void DeleteAllModels(int iteration)
+        {
+            IEnumerable<ModelData> ie = client.GetModels() as IEnumerable<ModelData>;
+            int count = ie.Count<ModelData>();
+
+            foreach (ModelData md in client.GetModels())
+            {
+                try {  
+                    client.DeleteModel(md.Id);
+                    Log.Ok("Successfully deleted Model {" + md.Id + "}. Attempt [" + iteration + "]");
+                }
+                catch (RequestFailedException e2)
+                {
+                    Log.Error("Failed to delete Model {" + md.Id + "}");
+                    //Log.Error(e2.Message);
+                    // skip this and go to the next one
+                }
+            }
+
+            try {
+                IEnumerable<ModelData> c = client.GetModels() as IEnumerable<ModelData>;
+                if (c.Count<ModelData>() > 0) DeleteAllModels(iteration + 1);
+            }
+            catch (Exception)
+            {
+                return;
             }
         }
 

--- a/ModelUploader/Program.cs
+++ b/ModelUploader/Program.cs
@@ -23,11 +23,14 @@ namespace ModelUploader
 
         private static DigitalTwinsClient client;
         private static string modelPath;
+        private static bool deleteFirst;
 
         private class CliOptions
         {
             [Option('p', "path", Required = true, HelpText = "The path to the on-disk directory holding DTDL models.")]
             public string ModelPath { get; set; }
+            [Option('d', "deletefirst", Required = false, HelpText = "Specify if you want to delete the models first, by default is false")]
+            public bool DeleteFirst { get; set; }
         }
 
         static void Main(string[] args)
@@ -36,7 +39,9 @@ namespace ModelUploader
                    .WithParsed(o =>
                    {
                        modelPath = o.ModelPath;
-                   });
+                       deleteFirst = o.DeleteFirst;
+                   }                   
+                   );
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -94,19 +99,91 @@ namespace ModelUploader
             }
 
             Log.Ok($"Service client created – ready to go");
-
             try
             {
+                // Delete All Models first
+                if (deleteFirst)
+                    DeleteAllModels(1);                
+
                 EnumerationOptions options = new EnumerationOptions() { RecurseSubdirectories = true };
                 foreach (string file in Directory.EnumerateFiles(modelPath, "*.json", options))
                 {
                     StreamReader r = new StreamReader(file);
                     string dtdl = r.ReadToEnd();
                     r.Close();
-                    Response<ModelData[]> res = client.CreateModels(new List<string>() { dtdl });
-                    Log.Ok($"Model {file.Split("\\").Last()} created successfully!");
-                    foreach (ModelData md in res.Value)
-                        LogResponse(md.Model);
+
+                    try
+                    {
+                        Response<ModelData[]> res = client.CreateModels(new List<string>() { dtdl });
+                        Log.Ok($"Model {file.Split("\\").Last()} created successfully!");
+                        foreach (ModelData md in res.Value)
+                            LogResponse(md.Model);
+                    }
+                    catch (RequestFailedException e)
+                    {
+                        switch (e.Status)
+                        {
+                            case 409:
+                                // 409 is when the Model already exists - so just skip this model
+                                Log.Ok($"Model {file.Split("\\").Last()} already exists, skipped!");
+                                break;
+                            case 400:
+                                // Model could not be uploaded because of a dependency
+
+                                // find the missing dependency Model in the message
+                                int missingInterfaceIndexStart = e.Message.IndexOf("dtmi:");
+                                int missingInterfaceIndexEnd = e.Message.IndexOf(";1", missingInterfaceIndexStart);
+                                string missingInterface = e.Message.Substring(missingInterfaceIndexStart, missingInterfaceIndexEnd - missingInterfaceIndexStart);
+                                int missingPartIndex = missingInterface.LastIndexOf(":");
+                                missingInterface = missingInterface.Substring(missingPartIndex + 1);
+
+                                string[] missingFile = Directory.GetFiles(modelPath, missingInterface + ".json*", SearchOption.AllDirectories);
+                                if (missingFile[0] == null || missingFile[0] == "") break;
+
+                                // Read the contents of the file
+                                StreamReader r1 = new StreamReader(missingFile[0]);
+                                string dtdlDependency = r1.ReadToEnd();
+                                r1.Close();
+
+                                try
+                                {
+                                    // Upload the dependency model 
+                                    Response<ModelData[]> res1 = client.CreateModels(new List<string>() { dtdlDependency });
+                                    Log.Ok($"Dependent Model {file.Split("\\").Last()} created successfully! Now proceeeding with the original model");
+                                    foreach (ModelData md1 in res1.Value)
+                                        LogResponse(md1.Model);
+                                }
+                                catch (RequestFailedException e1)
+                                {
+                                    // dependency file didnt work, bail
+                                    Log.Error($"Dependency Model {missingFile[0].Split("\\").Last()}");
+                                    Log.Error($"Response {e1.Status}: {e1.Message}");
+
+                                    Log.Error($"Original Model We were trying for {file.Split("\\").Last()}");
+                                    return;
+                                }
+
+                                // now try the original file back again
+                                try
+                                {
+                                    Response<ModelData[]> res = client.CreateModels(new List<string>() { dtdl });
+                                    Log.Ok($"Model {file.Split("\\").Last()} created successfully!");
+                                    foreach (ModelData md in res.Value)
+                                        LogResponse(md.Model);
+                                }
+                                catch (RequestFailedException e2)
+                                {
+                                    // didnt work again, bail
+                                    Log.Error($"Model {file.Split("\\").Last()}");
+                                    Log.Error($"Response {e2.Status}: {e2.Message}");
+                                    return;
+                                }
+
+                                break;
+                            default:
+                                break;
+                        }
+                    }
                 }
             }
             catch (RequestFailedException e)
@@ -116,6 +193,35 @@ namespace ModelUploader
             catch (Exception ex)
             {
                 Log.Error($"Error: {ex.Message}");
+            }
+        }
+
+        private static void DeleteAllModels(int iteration)
+        {
+            IEnumerable<ModelData> ie = client.GetModels() as IEnumerable<ModelData>;
+            int count = ie.Count<ModelData>();
+
+            foreach (ModelData md in client.GetModels())
+            {
+                try {  
+                    client.DeleteModel(md.Id);
+                    Log.Ok("Successfully deleted Model {" + md.Id + "}. Attempt [" + iteration + "]");
+                }
+                catch (RequestFailedException e2)
+                {
+                    //Log.Error("Failed to delete Model {" + md.Id + "}");
+                    //Log.Error(e2.Message);
+                    // skip this and go to the next one
+                }
+            }
+
+            try {
+                IEnumerable<ModelData> c = client.GetModels() as IEnumerable<ModelData>;
+                if (c.Count<ModelData>() > 0) DeleteAllModels(iteration + 1);
+            }
+            catch (Exception)
+            {
+                return;
             }
         }
 

--- a/ModelUploader/Program.cs
+++ b/ModelUploader/Program.cs
@@ -205,7 +205,12 @@ namespace ModelUploader
                                     Log.Error($"Could not find a definition for Interace {" + missingInterface + "}");
                                 }
                             }
-                            else {  
+                            else {
+                                if (missingFile.Count<string>() > 1)
+                                {
+                                    // More than one file was matched, log a warning
+                                    Log.Error("More than one file matched the prefix " + missingInterface + ".json in the ModelPath directory. Processing only the first");
+                                }
                                 // try to Upload the Model in the extends section
                                 exitProcess = UploadModel(missingFile[0]);
                             }
@@ -253,6 +258,11 @@ namespace ModelUploader
                 }
                 else
                 {
+                    if (missingFile.Count<string>() > 1)
+                    {
+                        // More than one file was matched, log a warning
+                        Log.Error("More than one file matched the prefix " + missingInterface + ".json in the ModelPath directory. Processing only the first");
+                    }                    
                     // try to Upload the Model that is referred in the Properties section
                     exitProcess = UploadModel(missingFile[0]);
                 }
@@ -262,9 +272,6 @@ namespace ModelUploader
 
         private static void DeleteAllModels(int iteration)
         {
-            IEnumerable<ModelData> ie = client.GetModels() as IEnumerable<ModelData>;
-            int count = ie.Count<ModelData>();
-
             foreach (ModelData md in client.GetModels())
             {
                 try

--- a/ModelUploader/Properties/launchSettings.json
+++ b/ModelUploader/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ModelUploader": {
       "commandName": "Project",
-      "commandLineArgs": "-p G:\\Work\\IoTWorkbench\\rec-extended-willowmodels\\Ontology\\REC\\ -d"
+      "commandLineArgs": "-p C:\\Users\\akshayj\\Documents\\GitHub\\willow\\Willow\\  "
     }
   }
 }

--- a/ModelUploader/Properties/launchSettings.json
+++ b/ModelUploader/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ModelUploader": {
       "commandName": "Project",
-      "commandLineArgs": "-p C:\\Users\\karlh\\Scratch\\Git\\opendigitaltwins-building\\Ontology"
+      "commandLineArgs": "-p G:\\Work\\IoTWorkbench\\rec-extended-willowmodels\\Ontology\\REC\\ -d"
     }
   }
 }

--- a/ModelUploader/Properties/launchSettings.json
+++ b/ModelUploader/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ModelUploader": {
       "commandName": "Project",
-      "commandLineArgs": "-p C:\\Users\\karlh\\Scratch\\Git\\opendigitaltwins-building\\Ontology"
+      "commandLineArgs": "-p G:\\Work\\IoTWorkbench\\rec-extended-willowmodels\\Ontology\\REC -d"
     }
   }
 }

--- a/ModelUploader/Properties/launchSettings.json
+++ b/ModelUploader/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ModelUploader": {
       "commandName": "Project",
-      "commandLineArgs": "-p G:\\Work\\IoTWorkbench\\rec-extended-willowmodels\\Ontology\\REC -d"
+      "commandLineArgs": "-p C:\\Users\\karlh\\Scratch\\Git\\opendigitaltwins-building\\Ontology"
     }
   }
 }

--- a/ModelUploader/README.md
+++ b/ModelUploader/README.md
@@ -22,3 +22,18 @@ In order for this tool to operate, the user must:
 ## Example usage
 
 `./ModelUploader -p /Users/karl/DTDLModels/`
+
+## Example usage with Deleting All Models First
+
+The "-d" option recursively deletes ALL Models from ADT Instance. You cannot use the -d option alone in this version (a -p option must be specified)
+
+`./ModelUploader -p /Users/karl/DTDLModels/` -d
+
+## Example usage with Uploading more than one set of models
+
+In order for this to work, the user must separate the models  into multiple different directories:
+
+`./ModelUploader -p /Users/karl/DTDLModels/REC` 
+`./ModelUploader -p /Users/karl/DTDLModels/Willow` 
+`./ModelUploader -p /Users/karl/DTDLModels/FoaF` 
+...etc

--- a/ModelUploader/serviceConfig.json
+++ b/ModelUploader/serviceConfig.json
@@ -1,5 +1,5 @@
 {
-  "tenantId": "<TenantIdHere>",
-  "clientId": "<ClientIdHere>",
-  "instanceUrl": "https://<ADT DNS here>"
+  "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+  "clientId": "f7400bff-2504-4e5f-8587-eda134e5a70d",
+  "instanceUrl": "https://adtspaceiqbim2adt.api.wus2.digitaltwins.azure.net"
 }

--- a/ModelUploader/serviceConfig.json
+++ b/ModelUploader/serviceConfig.json
@@ -1,5 +1,5 @@
 {
-  "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-  "clientId": "f7400bff-2504-4e5f-8587-eda134e5a70d",
-  "instanceUrl": "https://adtspaceiqbim2adt.api.wus2.digitaltwins.azure.net"
+  "tenantId": "<TenantIdHere>",
+  "clientId": "<ClientIdHere>",
+  "instanceUrl": "https://<ADT DNS here>"
 }


### PR DESCRIPTION
1. Added a feature for -d to delete all models 
2. Added major improvement so that if Model is not found - it recursively looks at Model references (in extends and in properties/components) and loads them first - and does this recursively
(REC models don't need this, but other models, e.g. Willow models did)