### PR TITLE
Remove Space Components from TenantUnit and rename occupancy to isOccupied

### DIFF
--- a/Ontology/Collection/SpaceCollection/TenantUnit.json
+++ b/Ontology/Collection/SpaceCollection/TenantUnit.json
@@ -13,54 +13,6 @@
       "minMultiplicity": 0,
       "name": "includes",
       "target": "dtmi:digitaltwins:rec_3_3:core:Space;1"
-    },
-    {
-      "@type": "Component",
-      "name": "area",
-      "displayName": {
-        "en": "Area"
-      },
-      "schema": "dtmi:digitaltwins:rec_3_3:SpaceArea;1"
-    },
-    {
-      "@type": "Component",
-      "name": "capacity",
-      "displayName": {
-        "en": "Capacity"
-      },
-      "schema": "dtmi:digitaltwins:rec_3_3:SpaceCapacity;1"
-    },
-    {
-      "@type": "Component",
-      "name": "temperature",
-      "displayName": {
-        "en": "Temperature"
-      },
-      "schema": "dtmi:digitaltwins:rec_3_3:SpaceTemperature;1"
-    },
-    {
-      "@type": "Component",
-      "name": "humidity",
-      "displayName": {
-        "en": "Humidity Average"
-      },
-      "schema": "dtmi:digitaltwins:rec_3_3:SpaceHumidity;1"
-    },
-    {
-      "@type": "Component",
-      "name": "CO2",
-      "displayName": {
-        "en": "CO2"
-      },
-      "schema": "dtmi:digitaltwins:rec_3_3:SpaceCO2;1"
-    },
-    {
-      "@type": "Component",
-      "name": "occupancy",
-      "displayName": {
-        "en": "Occupancy"
-      },
-      "schema": "dtmi:digitaltwins:rec_3_3:SpaceOccupancy;1"
     }
   ],
   "description": {

--- a/Ontology/Space/Components/SpaceOccupancy.json
+++ b/Ontology/Space/Components/SpaceOccupancy.json
@@ -7,9 +7,9 @@
   "contents": [
     {
       "@type": "Property",
-      "name": "occupancy",
+      "name": "isOccupied",
       "displayName": {
-        "en": "Occupancy"
+        "en": "Is Occupied"
       },
       "writable": true,
       "schema": "boolean"


### PR DESCRIPTION
see email
1.	SpaceCapacity and SpaceArea components – 
a.	Agree with Karl about it only being on Space and not on TenantUnit
b.	ACTION: Remove Space Components from TenantUnit (in the REC ontology) . Owner: @Alina Stanciu
2.	SpaceCO2, SpaceHumidity, SpaceTemperature Property Components Or Capabilities
a.	We saw the use of these as BOTH valid – as aggregate Temperature on a Floor AND as a Capability on Floor for Temperature (using TemperatureSensor)
b.	ACTION: DO NOTHING. Both of these models are allowable by the Ontology today, and we should leave it up to the developer of how they want to use it. They might choose the Capability route or the Property route
3.	SpaceOccupancy Component
a.	We do need both PeopleCount and Occupancy (since there are sensors that do ONE or the OTHER or sometimes both)
b.	Agree with Karl about the “occupancy” not signifying a Boolean value. 
c.	ACTION: Proposed name change: “isOccupied” . Owner: @Alina Stanciu (in the REC ontology) and @Rick Szcodronski (in the Willow ontology)
