### PR TITLE
Fixed wrong enum value name in Capability interface

### DIFF
--- a/Ontology/Capability/Capability.json
+++ b/Ontology/Capability/Capability.json
@@ -156,7 +156,7 @@
           },
           {
             "enumValue": "Compressed Air",
-            "name": "Compressed Air"
+            "name": "CompressedAir"
           },
           {
             "enumValue": "ColdDomesticWater",


### PR DESCRIPTION
Enum value uses 'Compressed Air' with space as name, which is invalid. Changed to 'CompressedAir'.

Proof from DTDLValidator:

```
*** Error parsing models
Error 1:
dtmi:digitaltwins:rec_3_3:core:Capability:_contents:__phenomenon:_schema:_enumValues:__Compressed Air;1's property 'name' has value 'Compressed Air', which is invalid. Modify the value of 'name' to make it match the regular expression '^[A-Za-z](?:[A-Za-z0-9_]*[A-Za-z0-9])?$'.
Primary ID: dtmi:digitaltwins:rec_3_3:core:Capability:_contents:__phenomenon:_schema:_enumValues:__Compressed Air;1
Secondary ID: 
Property: name
```