### PR TITLE
Fix enthalpysensor, regenerate BinarySensor

### DIFF
--- a/Ontology/Capability/Sensor/QuantitySensor/EnthalpySensor/SpecificEnthalpySensor.json
+++ b/Ontology/Capability/Sensor/QuantitySensor/EnthalpySensor/SpecificEnthalpySensor.json
@@ -1,8 +1,8 @@
 {
-  "@id": "dtmi:digitaltwins:rec_3_3:device:SpecificEnthalpySensorSensor;1",
+  "@id": "dtmi:digitaltwins:rec_3_3:device:SpecificEnthalpySensor;1",
   "@type": "Interface",
   "displayName": {
-    "en": "Specific enthalpy sensor sensor"
+    "en": "Specific enthalpy sensor"
   },
   "extends": "dtmi:digitaltwins:rec_3_3:device:EnthalpySensor;1",
   "@context": "dtmi:dtdl:context;2"

--- a/Ontology/Capability/Sensor/StateSensor/BinarySensor/BinarySensor.json
+++ b/Ontology/Capability/Sensor/StateSensor/BinarySensor/BinarySensor.json
@@ -1,24 +1,23 @@
 {
   "@id": "dtmi:digitaltwins:rec_3_3:device:BinarySensor;1",
   "@type": "Interface",
-  "displayName": {
-    "en": "Binary sensor"
-  },
-  "extends": "dtmi:digitaltwins:rec_3_3:device:StateSensor;1",
   "contents": [
     {
       "@type": "Property",
       "description": {
-        "en": "Most recently reported or set value of a device:BinarySensor."
+        "en": "Most recently reported or set value of a core:Capability."
       },
-      "name": "lastValue",
       "displayName": {
         "en": "last value"
       },
-      "writable": true,
-      "schema": "boolean"
+      "name": "lastValue",
+      "schema": "boolean",
+      "writable": true
     }
-    
   ],
+  "displayName": {
+    "en": "Binary sensor"
+  },
+  "extends": "dtmi:digitaltwins:rec_3_3:device:StateSensor;1",
   "@context": "dtmi:dtdl:context;2"
 }


### PR DESCRIPTION
This is just a bugfix on naming + regenerated BinarySensor from OWL models leading to slightly different field ordering.