### PR TITLE
Remove component-specific models

### DIFF
--- a/Ontology/Capability/Parameter/Setpoint/StateSetpoint/BinarySetpoint/OpenCloseSetpoint/OpenSetpoint/DamperOpenSetpoint/DamperOpenSetpoint.json
+++ b/Ontology/Capability/Parameter/Setpoint/StateSetpoint/BinarySetpoint/OpenCloseSetpoint/OpenSetpoint/DamperOpenSetpoint/DamperOpenSetpoint.json
@@ -1,9 +1,0 @@
-{
-  "@id": "dtmi:digitaltwins:rec_3_3:device:DamperOpenSetpoint;1",
-  "@type": "Interface",
-  "displayName": {
-    "en": "Damper open setpoint"
-  },
-  "extends": "dtmi:digitaltwins:rec_3_3:device:OpenSetpoint;1",
-  "@context": "dtmi:dtdl:context;2"
-}

--- a/Ontology/Capability/Parameter/Setpoint/StateSetpoint/BinarySetpoint/OpenCloseSetpoint/OpenSetpoint/DamperOpenSetpoint/ValveOpenSetpoint.json
+++ b/Ontology/Capability/Parameter/Setpoint/StateSetpoint/BinarySetpoint/OpenCloseSetpoint/OpenSetpoint/DamperOpenSetpoint/ValveOpenSetpoint.json
@@ -1,9 +1,0 @@
-{
-  "@id": "dtmi:digitaltwins:rec_3_3:device:ValveOpenSetpoint;1",
-  "@type": "Interface",
-  "displayName": {
-    "en": "Valve open setpoint"
-  },
-  "extends": "dtmi:digitaltwins:rec_3_3:device:DamperOpenSetpoint;1",
-  "@context": "dtmi:dtdl:context;2"
-}

--- a/Ontology/Capability/Sensor/StateSensor/BinarySensor/OpenCloseSensor/OpenSensor/DamperOpenSensor/DamperOpenSensor.json
+++ b/Ontology/Capability/Sensor/StateSensor/BinarySensor/OpenCloseSensor/OpenSensor/DamperOpenSensor/DamperOpenSensor.json
@@ -1,9 +1,0 @@
-{
-  "@id": "dtmi:digitaltwins:rec_3_3:device:DamperOpenSensor;1",
-  "@type": "Interface",
-  "displayName": {
-    "en": "Damper open sensor"
-  },
-  "extends": "dtmi:digitaltwins:rec_3_3:device:OpenSensor;1",
-  "@context": "dtmi:dtdl:context;2"
-}

--- a/Ontology/Capability/Sensor/StateSensor/BinarySensor/OpenCloseSensor/OpenSensor/DamperOpenSensor/ValveOpenSensor.json
+++ b/Ontology/Capability/Sensor/StateSensor/BinarySensor/OpenCloseSensor/OpenSensor/DamperOpenSensor/ValveOpenSensor.json
@@ -1,9 +1,0 @@
-{
-  "@id": "dtmi:digitaltwins:rec_3_3:device:ValveOpenSensor;1",
-  "@type": "Interface",
-  "displayName": {
-    "en": "Valve open sensor"
-  },
-  "extends": "dtmi:digitaltwins:rec_3_3:device:DamperOpenSensor;1",
-  "@context": "dtmi:dtdl:context;2"
-}


### PR DESCRIPTION
@hammar - the team at Optio3 noticed that we still had some remnant component-specific models that should be removed. Since we made the decision that we stop at "OpenSensor" and "OpenSetpoint" any further sub-classing gets defined by setting the assetComponent tag = Fan, Damper, Valve, etc.