### PR TITLE
Add quantitativeType

### DIFF
--- a/Ontology/Asset/ArchitecturalAsset/BarrierAsset/BarrierAsset.json
+++ b/Ontology/Asset/ArchitecturalAsset/BarrierAsset/BarrierAsset.json
@@ -3,21 +3,45 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "Length"],
       "displayName": {
         "en": "width"
       },
       "name": "width",
       "schema": "double",
+      "unit": "millimetre",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "width unit"
+      },
+      "name": "widthUnit",
+      "annotates": "width",
+      "overrides": "unit",
+      "schema": "LengthUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Length"],
       "displayName": {
         "en": "thickness"
       },
       "name": "thickness",
       "schema": "double",
+      "unit": "millimetre",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "thickness unit"
+      },
+      "name": "thicknessUnit",
+      "annotates": "thickness",
+      "overrides": "unit",
+      "schema": "LengthUnit",
       "writable": true
     },
     {
@@ -52,12 +76,24 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "Length"],
       "displayName": {
         "en": "height"
       },
       "name": "height",
       "schema": "double",
+      "unit": "millimetre",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "height unit"
+      },
+      "name": "heightUnit",
+      "annotates": "height",
+      "overrides": "unit",
+      "schema": "LengthUnit",
       "writable": true
     },
     {
@@ -70,10 +106,7 @@
       "writable": true
     },
     {
-      "@type": [
-        "TimeSpan",
-        "Property"
-      ],
+      "@type": ["TimeSpan", "Property"],
       "displayName": {
         "en": "fire rating"
       },

--- a/Ontology/Asset/ArchitecturalAsset/BarrierAsset/BarrierAsset.json
+++ b/Ontology/Asset/ArchitecturalAsset/BarrierAsset/BarrierAsset.json
@@ -140,6 +140,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:ArchitecturalAsset;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Asset.json
+++ b/Ontology/Asset/Asset.json
@@ -48,12 +48,24 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "Mass"],
       "displayName": {
         "en": "weight"
       },
       "name": "weight",
       "schema": "double",
+      "unit": "kilogram",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "weight unit"
+      },
+      "name": "weightUnit",
+      "annotates": "weight",
+      "overrides": "unit",
+      "schema": "MassUnit",
       "writable": true
     },
     {
@@ -296,6 +308,7 @@
     "en": "Asset"
   },
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Asset.json
+++ b/Ontology/Asset/Asset.json
@@ -309,6 +309,8 @@
   },
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Component/DuctConnection.json
+++ b/Ontology/Asset/Component/DuctConnection.json
@@ -78,6 +78,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Component;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Component/DuctConnection.json
+++ b/Ontology/Asset/Component/DuctConnection.json
@@ -3,12 +3,24 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "Length"],
       "displayName": {
         "en": "size"
       },
       "name": "size",
       "schema": "double",
+      "unit": "millimetre",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "size unit"
+      },
+      "name": "sizeUnit",
+      "annotates": "size",
+      "overrides": "unit",
+      "schema": "LengthUnit",
       "writable": true
     },
     {
@@ -65,6 +77,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Component;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Component/ElectricalBus.json
+++ b/Ontology/Asset/Component/ElectricalBus.json
@@ -25,10 +25,7 @@
       "writable": true
     },
     {
-      "@type": [
-        "Current",
-        "Property"
-      ],
+      "@type": ["Current", "Property"],
       "displayName": {
         "en": "current rating"
       },

--- a/Ontology/Asset/Component/Fan.json
+++ b/Ontology/Asset/Component/Fan.json
@@ -3,28 +3,49 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "Pressure"],
       "displayName": {
         "en": "nominal external static pressure"
       },
       "name": "nominalExternalStaticPressure",
       "schema": "double",
+      "unit": "pascal",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "nominal external static pressure unit"
+      },
+      "name": "nominalExternalStaticPressureUnit",
+      "annotates": "nominalExternalStaticPressure",
+      "overrides": "unit",
+      "schema": "PressureUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "VolumeFlowRate"],
       "displayName": {
         "en": "nominal airflow"
       },
       "name": "nominalAirflow",
       "schema": "double",
+      "unit": "litrePerSecond",
       "writable": true
     },
     {
-      "@type": [
-        "Power",
-        "Property"
-      ],
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "nominal airflow unit"
+      },
+      "name": "nominalAirflowUnit",
+      "annotates": "nominalAirflow",
+      "overrides": "unit",
+      "schema": "VolumeFlowRateUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Power", "Property"],
       "displayName": {
         "en": "motor power"
       },
@@ -34,21 +55,56 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "motor power unit"
+      },
+      "name": "motorPowerUnit",
+      "annotates": "motorPower",
+      "overrides": "unit",
+      "schema": "PowerUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "VolumeFlowRate"],
       "displayName": {
         "en": "minimum airflow rating"
       },
       "name": "minAirflowRating",
       "schema": "double",
+      "unit": "litrePerSecond",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "minimum airflow rating unit"
+      },
+      "name": "minAirflowRatingUnit",
+      "annotates": "minAirflowRating",
+      "overrides": "unit",
+      "schema": "VolumeFlowRateUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "VolumeFlowRate"],
       "displayName": {
         "en": "maximum airflow rating"
       },
       "name": "maxAirflowRating",
       "schema": "double",
+      "unit": "litrePerSecond",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "maximum airflow rating unit"
+      },
+      "name": "maxAirflowRatingUnit",
+      "annotates": "maxAirflowRating",
+      "overrides": "unit",
+      "schema": "VolumeFlowRateUnit",
       "writable": true
     },
     {

--- a/Ontology/Asset/Component/Fan.json
+++ b/Ontology/Asset/Component/Fan.json
@@ -136,6 +136,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Component;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Component/HVACCoolingMethod.json
+++ b/Ontology/Asset/Component/HVACCoolingMethod.json
@@ -34,12 +34,24 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "Length"],
       "displayName": {
         "en": "outside diameter"
       },
       "name": "outsideDiameter",
       "schema": "double",
+      "unit": "millimetre",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "outside diameter unit"
+      },
+      "name": "outsideDiameterUnit",
+      "annotates": "outsideDiameter",
+      "overrides": "unit",
+      "schema": "LengthUnit",
       "writable": true
     }
   ],
@@ -48,6 +60,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Component;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Component/HVACCoolingMethod.json
+++ b/Ontology/Asset/Component/HVACCoolingMethod.json
@@ -61,6 +61,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Component;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Component/HVACHeatingMethod.json
+++ b/Ontology/Asset/Component/HVACHeatingMethod.json
@@ -33,12 +33,24 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "Length"],
       "displayName": {
         "en": "outside diameter"
       },
       "name": "outsideDiameter",
       "schema": "double",
+      "unit": "millimetre",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "outside diameter unit"
+      },
+      "name": "outsideDiameterUnit",
+      "annotates": "outsideDiameter",
+      "overrides": "unit",
+      "schema": "LengthUnit",
       "writable": true
     }
   ],
@@ -47,6 +59,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Component;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Component/HVACHeatingMethod.json
+++ b/Ontology/Asset/Component/HVACHeatingMethod.json
@@ -60,6 +60,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Component;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Component/HeatTracing/HeatTracing.json
+++ b/Ontology/Asset/Component/HeatTracing/HeatTracing.json
@@ -42,6 +42,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Component;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Component/PipeConnection.json
+++ b/Ontology/Asset/Component/PipeConnection.json
@@ -3,30 +3,66 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "Length"],
       "displayName": {
         "en": "outside diameter"
       },
       "name": "outsideDiameter",
       "schema": "double",
+      "unit": "millimetre",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "outside diameter unit"
+      },
+      "name": "outsideDiameterUnit",
+      "annotates": "outsideDiameter",
+      "overrides": "unit",
+      "schema": "LengthUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Length"],
       "displayName": {
         "en": "nominal diameter"
       },
       "name": "nominalDiameter",
       "schema": "double",
+      "unit": "millimetre",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "nominal diameter unit"
+      },
+      "name": "nominalDiameterUnit",
+      "annotates": "nominalDiameter",
+      "overrides": "unit",
+      "schema": "LengthUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Length"],
       "displayName": {
         "en": "inside diameter"
       },
       "name": "insideDiameter",
       "schema": "double",
+      "unit": "millimetre",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "inside diameter unit"
+      },
+      "name": "insideDiameterUnit",
+      "annotates": "insideDiameter",
+      "overrides": "unit",
+      "schema": "LengthUnit",
       "writable": true
     }
   ],
@@ -35,6 +71,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Component;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Component/PipeConnection.json
+++ b/Ontology/Asset/Component/PipeConnection.json
@@ -72,6 +72,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Component;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Component/Pump/Pump.json
+++ b/Ontology/Asset/Component/Pump/Pump.json
@@ -34,33 +34,69 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "Pressure"],
       "displayName": {
         "en": "pressure capacity"
       },
       "name": "pressureCapacity",
       "schema": "double",
+      "unit": "bar",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "pressure capacity unit"
+      },
+      "name": "pressureCapacityUnit",
+      "annotates": "pressureCapacity",
+      "overrides": "unit",
+      "schema": "PressureUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Length"],
       "description": {
-        "en": "foot of head"
+        "en": "rated head"
       },
       "displayName": {
         "en": "head capacity"
       },
       "name": "headCapacity",
       "schema": "integer",
+      "unit": "metre",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "head capacity unit"
+      },
+      "name": "headCapacityUnit",
+      "annotates": "headCapacity",
+      "overrides": "unit",
+      "schema": "LengthUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "VolumeFlowRate"],
       "displayName": {
         "en": "flow capacity"
       },
       "name": "flowCapacity",
       "schema": "double",
+      "unit": "litrePerSecond",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "flow capacity unit"
+      },
+      "name": "flowCapacityUnit",
+      "annotates": "flowCapacity",
+      "overrides": "unit",
+      "schema": "VolumeFlowRateUnit",
       "writable": true
     },
     {
@@ -85,6 +121,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Component;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Component/Pump/Pump.json
+++ b/Ontology/Asset/Component/Pump/Pump.json
@@ -122,6 +122,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Component;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Component/Tank/Tank.json
+++ b/Ontology/Asset/Component/Tank/Tank.json
@@ -51,6 +51,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Component;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Component/Tank/Tank.json
+++ b/Ontology/Asset/Component/Tank/Tank.json
@@ -3,21 +3,45 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "Volume"],
       "displayName": {
         "en": "tank capacity"
       },
       "name": "tankCapacity",
       "schema": "double",
+      "unit": "litre",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "tank capacity unit"
+      },
+      "name": "tankCapacityUnit",
+      "annotates": "tankCapacity",
+      "overrides": "unit",
+      "schema": "VolumeUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Pressure"],
       "displayName": {
         "en": "system pressure"
       },
       "name": "systemPressure",
       "schema": "double",
+      "unit": "bar",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "system pressure unit"
+      },
+      "name": "systemPressureUnit",
+      "annotates": "systemPressure",
+      "overrides": "unit",
+      "schema": "PressureUnit",
       "writable": true
     }
   ],
@@ -26,6 +50,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Component;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Component/Valve/Valve.json
+++ b/Ontology/Asset/Component/Valve/Valve.json
@@ -3,21 +3,45 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "Pressure"],
       "displayName": {
         "en": "pressure capacity"
       },
       "name": "pressureCapacity",
       "schema": "double",
+      "unit": "bar",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "pressure capacity unit"
+      },
+      "name": "pressureCapacityUnit",
+      "annotates": "pressureCapacity",
+      "overrides": "unit",
+      "schema": "PressureUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "VolumeFlowRate"],
       "displayName": {
         "en": "flow capacity"
       },
       "name": "flowCapacity",
       "schema": "double",
+      "unit": "litrePerSecond",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "flow capacity unit"
+      },
+      "name": "flowCapacityUnit",
+      "annotates": "flowCapacity",
+      "overrides": "unit",
+      "schema": "VolumeFlowRateUnit",
       "writable": true
     },
     {
@@ -42,6 +66,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Component;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Component/Valve/Valve.json
+++ b/Ontology/Asset/Component/Valve/Valve.json
@@ -67,6 +67,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Component;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/ConveyanceEquipment/Elevator.json
+++ b/Ontology/Asset/Equipment/ConveyanceEquipment/Elevator.json
@@ -15,10 +15,7 @@
       "writable": true
     },
     {
-      "@type": [
-        "Mass",
-        "Property"
-      ],
+      "@type": ["Mass", "Property"],
       "displayName": {
         "en": "weight capacity"
       },
@@ -28,21 +25,56 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "weight capacity unit"
+      },
+      "name": "weightCapacityUnit",
+      "annotates": "weightCapacity",
+      "overrides": "unit",
+      "schema": "MassUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Velocity"],
       "displayName": {
         "en": "maximum travel speed"
       },
       "name": "maxTravelSpeed",
       "schema": "double",
+      "unit": "metrePerSecond",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "maximum travel speed unit"
+      },
+      "name": "maxTravelSpeedUnit",
+      "annotates": "maxTravelSpeed",
+      "overrides": "unit",
+      "schema": "VelocityUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Length"],
       "displayName": {
         "en": "maximum travel distance"
       },
       "name": "maxTravelDistance",
       "schema": "double",
+      "unit": "metre",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "maximum travel distance unit"
+      },
+      "name": "maxTravelDistanceUnit",
+      "annotates": "maxTravelDistance",
+      "overrides": "unit",
+      "schema": "LengthUnit",
       "writable": true
     },
     {

--- a/Ontology/Asset/Equipment/ConveyanceEquipment/Elevator.json
+++ b/Ontology/Asset/Equipment/ConveyanceEquipment/Elevator.json
@@ -93,6 +93,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:ConveyanceEquipment;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/ConveyanceEquipment/ElevatorMachine.json
+++ b/Ontology/Asset/Equipment/ConveyanceEquipment/ElevatorMachine.json
@@ -40,6 +40,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:ConveyanceEquipment;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/ConveyanceEquipment/ElevatorMachine.json
+++ b/Ontology/Asset/Equipment/ConveyanceEquipment/ElevatorMachine.json
@@ -3,10 +3,7 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": [
-        "Mass",
-        "Property"
-      ],
+      "@type": ["Mass", "Property"],
       "displayName": {
         "en": "weight capacity"
       },
@@ -16,10 +13,18 @@
       "writable": true
     },
     {
-      "@type": [
-        "Power",
-        "Property"
-      ],
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "weight capacity unit"
+      },
+      "name": "weightCapacityUnit",
+      "annotates": "weightCapacity",
+      "overrides": "unit",
+      "schema": "MassUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Power", "Property"],
       "displayName": {
         "en": "motor power"
       },

--- a/Ontology/Asset/Equipment/ConveyanceEquipment/Escalator.json
+++ b/Ontology/Asset/Equipment/ConveyanceEquipment/Escalator.json
@@ -3,37 +3,70 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "Length"],
       "displayName": {
         "en": "step width"
       },
       "name": "stepWidth",
       "schema": "double",
+      "unit": "millimetre",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "step width unit"
+      },
+      "name": "stepWidthUnit",
+      "annotates": "stepWidth",
+      "overrides": "unit",
+      "schema": "LengthUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Length"],
       "displayName": {
         "en": "maximum vertical rise"
       },
       "name": "maxVerticalRise",
       "schema": "double",
+      "unit": "metre",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "maximum vertical rise unit"
+      },
+      "name": "maxVerticalRiseUnit",
+      "annotates": "maxVerticalRise",
+      "overrides": "unit",
+      "schema": "LengthUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Velocity"],
       "displayName": {
         "en": "maximum travel speed"
       },
       "name": "maxTravelSpeed",
       "schema": "double",
+      "unit": "metrePerSecond",
       "writable": true
     },
     {
-      "@type": [
-        "Angle",
-        "Property"
-      ],
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "maximum travel speed unit"
+      },
+      "name": "maxTravelSpeedUnit",
+      "annotates": "maxTravelSpeed",
+      "overrides": "unit",
+      "schema": "VelocityUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Angle", "Property"],
       "displayName": {
         "en": "inclination"
       },

--- a/Ontology/Asset/Equipment/ConveyanceEquipment/Escalator.json
+++ b/Ontology/Asset/Equipment/ConveyanceEquipment/Escalator.json
@@ -82,6 +82,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:ConveyanceEquipment;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/ConveyanceEquipment/MovingWalkway.json
+++ b/Ontology/Asset/Equipment/ConveyanceEquipment/MovingWalkway.json
@@ -3,37 +3,70 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "Length"],
       "displayName": {
         "en": "step width"
       },
       "name": "stepWidth",
       "schema": "double",
+      "unit": "millimetre",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "step width unit"
+      },
+      "name": "stepWidthUnit",
+      "annotates": "stepWidth",
+      "overrides": "unit",
+      "schema": "LengthUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Velocity"],
       "displayName": {
         "en": "maximum travel speed"
       },
       "name": "maxTravelSpeed",
       "schema": "double",
+      "unit": "metrePerSecond",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "maximum travel speed unit"
+      },
+      "name": "maxTravelSpeedUnit",
+      "annotates": "maxTravelSpeed",
+      "overrides": "unit",
+      "schema": "VelocityUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Length"],
       "displayName": {
         "en": "maximum length"
       },
       "name": "maxLength",
       "schema": "double",
+      "unit": "metre",
       "writable": true
     },
     {
-      "@type": [
-        "Angle",
-        "Property"
-      ],
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "maximum length unit"
+      },
+      "name": "maxLengthUnit",
+      "annotates": "maxLength",
+      "overrides": "unit",
+      "schema": "LengthUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Angle", "Property"],
       "displayName": {
         "en": "inclination"
       },

--- a/Ontology/Asset/Equipment/ConveyanceEquipment/MovingWalkway.json
+++ b/Ontology/Asset/Equipment/ConveyanceEquipment/MovingWalkway.json
@@ -82,6 +82,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:ConveyanceEquipment;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/ElectricalEquipment/ElectricalDistributionEquipment/Busway.json
+++ b/Ontology/Asset/Equipment/ElectricalEquipment/ElectricalDistributionEquipment/Busway.json
@@ -12,10 +12,7 @@
       "writable": true
     },
     {
-      "@type": [
-        "Voltage",
-        "Property"
-      ],
+      "@type": ["Voltage", "Property"],
       "displayName": {
         "en": "input voltage"
       },

--- a/Ontology/Asset/Equipment/ElectricalEquipment/ElectricalDistributionEquipment/ElectricalPanelboard/ElectricalPanelboard.json
+++ b/Ontology/Asset/Equipment/ElectricalEquipment/ElectricalDistributionEquipment/ElectricalPanelboard/ElectricalPanelboard.json
@@ -34,10 +34,7 @@
       "writable": true
     },
     {
-      "@type": [
-        "Voltage",
-        "Property"
-      ],
+      "@type": ["Voltage", "Property"],
       "displayName": {
         "en": "input voltage"
       },

--- a/Ontology/Asset/Equipment/ElectricalEquipment/ElectricalDistributionEquipment/ElectricalPanelboard/ElectricalPanelboardMCB.json
+++ b/Ontology/Asset/Equipment/ElectricalEquipment/ElectricalDistributionEquipment/ElectricalPanelboard/ElectricalPanelboardMCB.json
@@ -3,10 +3,7 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": [
-        "Current",
-        "Property"
-      ],
+      "@type": ["Current", "Property"],
       "displayName": {
         "en": "main circuit breaker rating"
       },

--- a/Ontology/Asset/Equipment/ElectricalEquipment/ElectricalDistributionEquipment/Switchboard.json
+++ b/Ontology/Asset/Equipment/ElectricalEquipment/ElectricalDistributionEquipment/Switchboard.json
@@ -12,10 +12,7 @@
       "writable": true
     },
     {
-      "@type": [
-        "Voltage",
-        "Property"
-      ],
+      "@type": ["Voltage", "Property"],
       "displayName": {
         "en": "input voltage"
       },

--- a/Ontology/Asset/Equipment/ElectricalEquipment/ElectricalDistributionEquipment/Switchgear.json
+++ b/Ontology/Asset/Equipment/ElectricalEquipment/ElectricalDistributionEquipment/Switchgear.json
@@ -12,10 +12,7 @@
       "writable": true
     },
     {
-      "@type": [
-        "Voltage",
-        "Property"
-      ],
+      "@type": ["Voltage", "Property"],
       "displayName": {
         "en": "input voltage"
       },

--- a/Ontology/Asset/Equipment/ElectricalEquipment/ElectricalDistributionEquipment/TransferSwitch/TransferSwitch.json
+++ b/Ontology/Asset/Equipment/ElectricalEquipment/ElectricalDistributionEquipment/TransferSwitch/TransferSwitch.json
@@ -25,10 +25,7 @@
       "writable": true
     },
     {
-      "@type": [
-        "Current",
-        "Property"
-      ],
+      "@type": ["Current", "Property"],
       "displayName": {
         "en": "mains rating"
       },

--- a/Ontology/Asset/Equipment/ElectricalEquipment/ElectricalDistributionEquipment/Transformer.json
+++ b/Ontology/Asset/Equipment/ElectricalEquipment/ElectricalDistributionEquipment/Transformer.json
@@ -3,10 +3,7 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": [
-        "Voltage",
-        "Property"
-      ],
+      "@type": ["Voltage", "Property"],
       "displayName": {
         "en": "secondary voltage"
       },
@@ -16,10 +13,7 @@
       "writable": true
     },
     {
-      "@type": [
-        "Voltage",
-        "Property"
-      ],
+      "@type": ["Voltage", "Property"],
       "displayName": {
         "en": "primary voltage"
       },
@@ -38,12 +32,13 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ApparentPower"],
       "displayName": {
         "en": "size (KVA)"
       },
       "name": "sizeKVA",
       "schema": "integer",
+      "unit": "kilovoltAmpere",
       "writable": true
     },
     {

--- a/Ontology/Asset/Equipment/ElectricalEquipment/ElectricalGenerationStorageEquipment/Generator/Generator.json
+++ b/Ontology/Asset/Equipment/ElectricalEquipment/ElectricalGenerationStorageEquipment/Generator/Generator.json
@@ -3,10 +3,7 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": [
-        "Voltage",
-        "Property"
-      ],
+      "@type": ["Voltage", "Property"],
       "displayName": {
         "en": "output voltage"
       },
@@ -56,7 +53,7 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "Frequency"],
       "description": {
         "en": "Hz"
       },
@@ -65,40 +62,63 @@
       },
       "name": "frequency",
       "schema": "integer",
+      "unit": "hertz",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "Volume"],
       "displayName": {
         "en": "day tank capacity"
       },
       "name": "dayTankCapacity",
       "schema": "double",
+      "unit": "litre",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "day tank capacity unit"
+      },
+      "name": "dayTankCapacityUnit",
+      "annotates": "dayTankCapacity",
+      "overrides": "unit",
+      "schema": "VolumeUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Volume"],
       "displayName": {
         "en": "bulk storage capacity"
       },
       "name": "bulkStorageCapacity",
       "schema": "double",
+      "unit": "litre",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "bulk storage capacity unit"
+      },
+      "name": "bulkStorageCapacityUnit",
+      "annotates": "bulkStorageCapacity",
+      "overrides": "unit",
+      "schema": "VolumeUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ApparentPower"],
       "displayName": {
         "en": "standby power rating (KVA)"
       },
       "name": "standbyPowerKVA",
       "schema": "integer",
+      "unit": "kilovoltAmpere",
       "writable": true
     },
     {
-      "@type": [
-        "Power",
-        "Property"
-      ],
+      "@type": ["Property", "Power"],
       "displayName": {
         "en": "standby power rating"
       },
@@ -108,19 +128,17 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ApparentPower"],
       "displayName": {
         "en": "prime power rating (KVA)"
       },
       "name": "primePowerKVA",
       "schema": "integer",
+      "unit": "kilovoltAmpere",
       "writable": true
     },
     {
-      "@type": [
-        "Power",
-        "Property"
-      ],
+      "@type": ["Property", "Power"],
       "displayName": {
         "en": "prime power rating"
       },

--- a/Ontology/Asset/Equipment/ElectricalEquipment/ElectricalGenerationStorageEquipment/Generator/Generator.json
+++ b/Ontology/Asset/Equipment/ElectricalEquipment/ElectricalGenerationStorageEquipment/Generator/Generator.json
@@ -154,6 +154,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:ElectricalGenerationStorageEquipment;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/ElectricalEquipment/ElectricalGenerationStorageEquipment/UPS.json
+++ b/Ontology/Asset/Equipment/ElectricalEquipment/ElectricalGenerationStorageEquipment/UPS.json
@@ -3,10 +3,7 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": [
-        "TimeSpan",
-        "Property"
-      ],
+      "@type": ["TimeSpan", "Property"],
       "displayName": {
         "en": "runtime"
       },
@@ -16,19 +13,17 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ApparentPower"],
       "displayName": {
         "en": "power output (KVA)"
       },
       "name": "powerOutputKVA",
       "schema": "integer",
+      "unit": "kilovoltAmpere",
       "writable": true
     },
     {
-      "@type": [
-        "Power",
-        "Property"
-      ],
+      "@type": ["Power", "Property"],
       "displayName": {
         "en": "power output"
       },
@@ -38,10 +33,7 @@
       "writable": true
     },
     {
-      "@type": [
-        "Voltage",
-        "Property"
-      ],
+      "@type": ["Voltage", "Property"],
       "displayName": {
         "en": "output voltage"
       },
@@ -73,10 +65,7 @@
       "writable": true
     },
     {
-      "@type": [
-        "Voltage",
-        "Property"
-      ],
+      "@type": ["Voltage", "Property"],
       "displayName": {
         "en": "input voltage"
       },

--- a/Ontology/Asset/Equipment/HVACEquipment/AirHandlingUnit/AirHandlingUnit.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/AirHandlingUnit/AirHandlingUnit.json
@@ -377,6 +377,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:HVACEquipment;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/AirHandlingUnit/AirHandlingUnit.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/AirHandlingUnit/AirHandlingUnit.json
@@ -98,30 +98,87 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "EnergyRate"],
       "displayName": {
         "en": "nominal heating capacity"
       },
       "name": "nominalHeatingCapacity",
       "schema": "double",
+      "unit": "britishThermalUnitPerHour",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "nominal heating capacity unit"
+      },
+      "name": "nominalHeatingCapacityUnit",
+      "annotates": "nominalHeatingCapacity",
+      "overrides": "unit",
+      "schema": "EnergyRateUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "EnergyRate"],
       "displayName": {
         "en": "nominal cooling capacity"
       },
       "name": "nominalCoolingCapacity",
       "schema": "double",
+      "unit": "britishThermalUnitPerHour",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "nominal cooling capacity unit"
+      },
+      "name": "nominalCoolingCapacityUnit",
+      "annotates": "nominalCoolingCapacity",
+      "overrides": "unit",
+      "schema": "EnergyRateUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "EnergyRate"],
+      "displayName": {
+        "en": "net sensible heating capacity"
+      },
+      "name": "netSensibleHeatingCapacity",
+      "schema": "double",
+      "unit": "britishThermalUnitPerHour",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "net sensible heating capacity unit"
+      },
+      "name": "netSensibleHeatingCapacityUnit",
+      "annotates": "netSensibleHeatingCapacity",
+      "overrides": "unit",
+      "schema": "EnergyRateUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "EnergyRate"],
       "displayName": {
         "en": "net sensible cooling capacity"
       },
       "name": "netSensibleCoolingCapacity",
       "schema": "double",
+      "unit": "britishThermalUnitPerHour",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "net sensible cooling capacity unit"
+      },
+      "name": "netSensibleCoolingCapacityUnit",
+      "annotates": "netSensibleCoolingCapacity",
+      "overrides": "unit",
+      "schema": "EnergyRateUnit",
       "writable": true
     },
     {
@@ -319,6 +376,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:HVACEquipment;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/Chiller.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/Chiller.json
@@ -116,6 +116,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:HVACEquipment;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/Chiller.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/Chiller.json
@@ -34,21 +34,45 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "EnergyRate"],
       "displayName": {
         "en": "nominal cooling capacity"
       },
       "name": "nominalCoolingCapacity",
       "schema": "double",
+      "unit": "britishThermalUnitPerHour",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "nominal cooling capacity unit"
+      },
+      "name": "nominalCoolingCapacityUnit",
+      "annotates": "nominalCoolingCapacity",
+      "overrides": "unit",
+      "schema": "EnergyRateUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "EnergyRate"],
       "displayName": {
         "en": "net sensible cooling capacity"
       },
       "name": "netSensibleCoolingCapacity",
       "schema": "double",
+      "unit": "britishThermalUnitPerHour",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "net sensible cooling capacity unit"
+      },
+      "name": "netSensibleCoolingCapacityUnit",
+      "annotates": "netSensibleCoolingCapacity",
+      "overrides": "unit",
+      "schema": "EnergyRateUnit",
       "writable": true
     },
     {
@@ -91,6 +115,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:HVACEquipment;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/CondensingUnit.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/CondensingUnit.json
@@ -133,6 +133,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:HVACEquipment;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/CondensingUnit.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/CondensingUnit.json
@@ -34,39 +34,87 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "EnergyRate"],
       "displayName": {
         "en": "nominal heating capacity"
       },
       "name": "nominalHeatingCapacity",
       "schema": "double",
+      "unit": "britishThermalUnitPerHour",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "nominal heating capacity unit"
+      },
+      "name": "nominalHeatingCapacityUnit",
+      "annotates": "nominalHeatingCapacity",
+      "overrides": "unit",
+      "schema": "EnergyRateUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "EnergyRate"],
       "displayName": {
         "en": "nominal cooling capacity"
       },
       "name": "nominalCoolingCapacity",
       "schema": "double",
+      "unit": "britishThermalUnitPerHour",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "nominal cooling capacity unit"
+      },
+      "name": "nominalCoolingCapacityUnit",
+      "annotates": "nominalCoolingCapacity",
+      "overrides": "unit",
+      "schema": "EnergyRateUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "EnergyRate"],
       "displayName": {
         "en": "net sensible heating capacity"
       },
       "name": "netSensibleHeatingCapacity",
       "schema": "double",
+      "unit": "britishThermalUnitPerHour",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "net sensible heating capacity unit"
+      },
+      "name": "netSensibleHeatingCapacityUnit",
+      "annotates": "netSensibleHeatingCapacity",
+      "overrides": "unit",
+      "schema": "EnergyRateUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "EnergyRate"],
       "displayName": {
         "en": "net sensible cooling capacity"
       },
       "name": "netSensibleCoolingCapacity",
       "schema": "double",
+      "unit": "britishThermalUnitPerHour",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "net sensible cooling capacity unit"
+      },
+      "name": "netSensibleCoolingCapacityUnit",
+      "annotates": "netSensibleCoolingCapacity",
+      "overrides": "unit",
+      "schema": "EnergyRateUnit",
       "writable": true
     },
     {
@@ -84,6 +132,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:HVACEquipment;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/CoolingTower.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/CoolingTower.json
@@ -59,6 +59,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:HVACEquipment;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/CoolingTower.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/CoolingTower.json
@@ -3,21 +3,45 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "EnergyRate"],
       "displayName": {
         "en": "nominal cooling capacity"
       },
       "name": "nominalCoolingCapacity",
       "schema": "double",
+      "unit": "britishThermalUnitPerHour",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "nominal cooling capacity unit"
+      },
+      "name": "nominalCoolingCapacityUnit",
+      "annotates": "nominalCoolingCapacity",
+      "overrides": "unit",
+      "schema": "EnergyRateUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "VolumeFlowRate"],
       "displayName": {
         "en": "flow capacity"
       },
       "name": "flowCapacity",
       "schema": "double",
+      "unit": "litrePerSecond",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "flow capacity unit"
+      },
+      "name": "flowCapacityUnit",
+      "annotates": "flowCapacity",
+      "overrides": "unit",
+      "schema": "VolumeFlowRateUnit",
       "writable": true
     },
     {
@@ -34,6 +58,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:HVACEquipment;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/Damper/FireDamper/FireDamper.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/Damper/FireDamper/FireDamper.json
@@ -3,10 +3,7 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": [
-        "TimeSpan",
-        "Property"
-      ],
+      "@type": ["TimeSpan", "Property"],
       "displayName": {
         "en": "fire rating"
       },

--- a/Ontology/Asset/Equipment/HVACEquipment/HVACFan/CeilingFan.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/HVACFan/CeilingFan.json
@@ -40,6 +40,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:HVACFan;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/HVACFan/CeilingFan.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/HVACFan/CeilingFan.json
@@ -3,10 +3,7 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": [
-        "AngularVelocity",
-        "Property"
-      ],
+      "@type": ["AngularVelocity", "Property"],
       "displayName": {
         "en": "maximum rotation speed"
       },
@@ -16,12 +13,24 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "Length"],
       "displayName": {
         "en": "blade diameter"
       },
       "name": "bladeDiameter",
       "schema": "double",
+      "unit": "millimetre",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "blade diameter unit"
+      },
+      "name": "bladeDiameterUnit",
+      "annotates": "bladeDiameter",
+      "overrides": "unit",
+      "schema": "LengthUnit",
       "writable": true
     }
   ],

--- a/Ontology/Asset/Equipment/HVACEquipment/HVACWaterTreatment/WaterFilter.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/HVACWaterTreatment/WaterFilter.json
@@ -3,12 +3,24 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "Pressure"],
       "displayName": {
         "en": "working pressure"
       },
       "name": "workingPressure",
       "schema": "double",
+      "unit": "bar",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "working pressure unit"
+      },
+      "name": "workingPressureUnit",
+      "annotates": "workingPressure",
+      "overrides": "unit",
+      "schema": "PressureUnit",
       "writable": true
     },
     {
@@ -21,25 +33,49 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "Volume"],
       "displayName": {
         "en": "tank capacity"
       },
       "name": "tankCapacity",
       "schema": "double",
+      "unit": "litre",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "tank capacity unit"
+      },
+      "name": "tankCapacityUnit",
+      "annotates": "tankCapacity",
+      "overrides": "unit",
+      "schema": "VolumeUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "VolumeFlowRate"],
       "displayName": {
         "en": "flow capacity"
       },
       "name": "flowCapacity",
       "schema": "double",
+      "unit": "litrePerSecond",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "flow capacity unit"
+      },
+      "name": "flowCapacityUnit",
+      "annotates": "flowCapacity",
+      "overrides": "unit",
+      "schema": "VolumeFlowRateUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Length"],
       "description": {
         "en": "microns"
       },
@@ -47,6 +83,7 @@
         "en": "filtration rating"
       },
       "name": "filtrationRating",
+      "unit": "micrometre",
       "schema": "integer",
       "writable": true
     }
@@ -56,6 +93,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:HVACWaterTreatment;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/HVACWaterTreatment/WaterFilter.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/HVACWaterTreatment/WaterFilter.json
@@ -94,6 +94,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:HVACWaterTreatment;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/HeatExchanger.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/HeatExchanger.json
@@ -3,57 +3,129 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "Temperature"],
       "displayName": {
         "en": "secondary maximum temperature"
       },
       "name": "secondaryMaxTemperature",
       "schema": "double",
+      "unit": "degreeCelsius",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "secondary maximum temperature unit"
+      },
+      "name": "secondaryMaxTemperatureUnit",
+      "annotates": "secondaryMaxTemperature",
+      "overrides": "unit",
+      "schema": "TemperatureUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Pressure"],
       "displayName": {
         "en": "secondary maximum pressure"
       },
       "name": "secondaryMaxPressure",
       "schema": "double",
+      "unit": "bar",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "secondary maximum pressure unit"
+      },
+      "name": "secondaryMaxPressureUnit",
+      "annotates": "secondaryMaxPressure",
+      "overrides": "unit",
+      "schema": "PressureUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "VolumeFlowRate"],
       "displayName": {
         "en": "secondary flow capacity"
       },
       "name": "secondaryFlowCapacity",
       "schema": "double",
+      "unit": "litrePerSecond",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "secondary flow capacity unit"
+      },
+      "name": "secondaryFlowCapacityUnit",
+      "annotates": "secondaryFlowCapacity",
+      "overrides": "unit",
+      "schema": "VolumeFlowRateUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Temperature"],
       "displayName": {
         "en": "primary maximum temperature"
       },
       "name": "primaryMaxTemperature",
       "schema": "double",
+      "unit": "degreeCelsius",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "primary maximum temperature unit"
+      },
+      "name": "primaryMaxTemperatureUnit",
+      "annotates": "primaryMaxTemperature",
+      "overrides": "unit",
+      "schema": "TemperatureUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Pressure"],
       "displayName": {
         "en": "primary maximum pressure"
       },
       "name": "primaryMaxPressure",
       "schema": "double",
+      "unit": "bar",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "primary maximum pressure unit"
+      },
+      "name": "primaryMaxPressureUnit",
+      "annotates": "primaryMaxPressure",
+      "overrides": "unit",
+      "schema": "PressureUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "VolumeFlowRate"],
       "displayName": {
         "en": "primary flow capacity"
       },
       "name": "primaryFlowCapacity",
       "schema": "double",
+      "unit": "litrePerSecond",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "primary flow capacity unit"
+      },
+      "name": "primaryFlowCapacityUnit",
+      "annotates": "primaryFlowCapacity",
+      "overrides": "unit",
+      "schema": "VolumeFlowRateUnit",
       "writable": true
     }
   ],
@@ -62,6 +134,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:HVACEquipment;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/HeatExchanger.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/HeatExchanger.json
@@ -135,6 +135,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:HVACEquipment;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/TerminalUnit/FanCoilUnit/FanCoilUnit.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/TerminalUnit/FanCoilUnit/FanCoilUnit.json
@@ -141,6 +141,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:TerminalUnit;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/TerminalUnit/FanCoilUnit/FanCoilUnit.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/TerminalUnit/FanCoilUnit/FanCoilUnit.json
@@ -34,21 +34,45 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "EnergyRate"],
       "displayName": {
         "en": "nominal cooling capacity"
       },
       "name": "nominalCoolingCapacity",
       "schema": "double",
+      "unit": "britishThermalUnitPerHour",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "nominal cooling capacity unit"
+      },
+      "name": "nominalCoolingCapacityUnit",
+      "annotates": "nominalCoolingCapacity",
+      "overrides": "unit",
+      "schema": "EnergyRateUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "EnergyRate"],
       "displayName": {
         "en": "net sensible cooling capacity"
       },
       "name": "netSensibleCoolingCapacity",
       "schema": "double",
+      "unit": "britishThermalUnitPerHour",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "net sensible cooling capacity unit"
+      },
+      "name": "netSensibleCoolingCapacityUnit",
+      "annotates": "netSensibleCoolingCapacity",
+      "overrides": "unit",
+      "schema": "EnergyRateUnit",
       "writable": true
     },
     {
@@ -116,6 +140,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:TerminalUnit;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/TerminalUnit/FanCoilUnit/FanCoilUnitReheat.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/TerminalUnit/FanCoilUnit/FanCoilUnitReheat.json
@@ -3,12 +3,24 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "EnergyRate"],
       "displayName": {
         "en": "nominal heating capacity"
       },
       "name": "nominalHeatingCapacity",
       "schema": "double",
+      "unit": "britishThermalUnitPerHour",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "nominal heating capacity unit"
+      },
+      "name": "nominalHeatingCapacityUnit",
+      "annotates": "nominalHeatingCapacity",
+      "overrides": "unit",
+      "schema": "EnergyRateUnit",
       "writable": true
     },
     {
@@ -25,6 +37,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:FanCoilUnit;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/TerminalUnit/FanCoilUnit/FanCoilUnitReheat.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/TerminalUnit/FanCoilUnit/FanCoilUnitReheat.json
@@ -38,6 +38,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:FanCoilUnit;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/TerminalUnit/TerminalUnit.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/TerminalUnit/TerminalUnit.json
@@ -59,6 +59,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:HVACEquipment;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/TerminalUnit/TerminalUnit.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/TerminalUnit/TerminalUnit.json
@@ -3,21 +3,45 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "VolumeFlowRate"],
       "displayName": {
         "en": "minimum airflow rating"
       },
       "name": "minAirflowRating",
       "schema": "double",
+      "unit": "litrePerSecond",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "minimum airflow rating unit"
+      },
+      "name": "minAirflowRatingUnit",
+      "annotates": "minAirflowRating",
+      "overrides": "unit",
+      "schema": "VolumeFlowRateUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "VolumeFlowRate"],
       "displayName": {
         "en": "maximum airflow rating"
       },
       "name": "maxAirflowRating",
       "schema": "double",
+      "unit": "litrePerSecond",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "maximum airflow rating unit"
+      },
+      "name": "maxAirflowRatingUnit",
+      "annotates": "maxAirflowRating",
+      "overrides": "unit",
+      "schema": "VolumeFlowRateUnit",
       "writable": true
     },
     {
@@ -34,6 +58,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:HVACEquipment;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/TerminalUnit/VAVBox/FanPoweredBox/FanPoweredBoxReheat.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/TerminalUnit/VAVBox/FanPoweredBox/FanPoweredBoxReheat.json
@@ -3,12 +3,24 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "EnergyRate"],
       "displayName": {
         "en": "nominal heating capacity"
       },
       "name": "nominalHeatingCapacity",
       "schema": "double",
+      "unit": "britishThermalUnitPerHour",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "nominal heating capacity unit"
+      },
+      "name": "nominalHeatingCapacityUnit",
+      "annotates": "nominalHeatingCapacity",
+      "overrides": "unit",
+      "schema": "EnergyRateUnit",
       "writable": true
     },
     {
@@ -25,6 +37,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:FanPoweredBox;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/TerminalUnit/VAVBox/FanPoweredBox/FanPoweredBoxReheat.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/TerminalUnit/VAVBox/FanPoweredBox/FanPoweredBoxReheat.json
@@ -38,6 +38,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:FanPoweredBox;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/TerminalUnit/VAVBox/VAVBoxReheat.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/TerminalUnit/VAVBox/VAVBoxReheat.json
@@ -38,6 +38,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:VAVBox;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/TerminalUnit/VAVBox/VAVBoxReheat.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/TerminalUnit/VAVBox/VAVBoxReheat.json
@@ -3,12 +3,24 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "EnergyRate"],
       "displayName": {
         "en": "nominal heating capacity"
       },
       "name": "nominalHeatingCapacity",
       "schema": "double",
+      "unit": "britishThermalUnitPerHour",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "nominal heating capacity unit"
+      },
+      "name": "nominalHeatingCapacityUnit",
+      "annotates": "nominalHeatingCapacity",
+      "overrides": "unit",
+      "schema": "EnergyRateUnit",
       "writable": true
     },
     {
@@ -25,6 +37,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:VAVBox;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/UnitHeater/ElectricUnitHeater.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/UnitHeater/ElectricUnitHeater.json
@@ -3,10 +3,7 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": [
-        "Power",
-        "Property"
-      ],
+      "@type": ["Power", "Property"],
       "displayName": {
         "en": "power input"
       },

--- a/Ontology/Asset/Equipment/HVACEquipment/UnitHeater/HotWaterUnitHeater.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/UnitHeater/HotWaterUnitHeater.json
@@ -30,6 +30,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:UnitHeater;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/UnitHeater/HotWaterUnitHeater.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/UnitHeater/HotWaterUnitHeater.json
@@ -3,12 +3,24 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "VolumeFlowRate"],
       "displayName": {
         "en": "flow capacity"
       },
       "name": "flowCapacity",
       "schema": "double",
+      "unit": "litrePerSecond",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "flow capacity unit"
+      },
+      "name": "flowCapacityUnit",
+      "annotates": "flowCapacity",
+      "overrides": "unit",
+      "schema": "VolumeFlowRateUnit",
       "writable": true
     }
   ],
@@ -17,6 +29,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:UnitHeater;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/UnitHeater/UnitHeater.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/UnitHeater/UnitHeater.json
@@ -68,6 +68,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:HVACEquipment;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/HVACEquipment/UnitHeater/UnitHeater.json
+++ b/Ontology/Asset/Equipment/HVACEquipment/UnitHeater/UnitHeater.json
@@ -25,12 +25,24 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "EnergyRate"],
       "displayName": {
         "en": "nominal heating capacity"
       },
       "name": "nominalHeatingCapacity",
       "schema": "double",
+      "unit": "britishThermalUnitPerHour",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "nominal heating capacity unit"
+      },
+      "name": "nominalHeatingCapacityUnit",
+      "annotates": "nominalHeatingCapacity",
+      "overrides": "unit",
+      "schema": "EnergyRateUnit",
       "writable": true
     },
     {
@@ -55,6 +67,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:HVACEquipment;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Equipment/ICTEquipment/SensorEquipment/SensorEquipment.json
+++ b/Ontology/Asset/Equipment/ICTEquipment/SensorEquipment/SensorEquipment.json
@@ -26,6 +26,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:ICTEquipment;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Equipment/LightingEquipment/Luminaire.json
+++ b/Ontology/Asset/Equipment/LightingEquipment/Luminaire.json
@@ -3,10 +3,7 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": [
-        "Power",
-        "Property"
-      ],
+      "@type": ["Power", "Property"],
       "displayName": {
         "en": "power input"
       },

--- a/Ontology/Asset/Equipment/Meter/ElectricityMeter.json
+++ b/Ontology/Asset/Equipment/Meter/ElectricityMeter.json
@@ -25,10 +25,7 @@
       "writable": true
     },
     {
-      "@type": [
-        "Voltage",
-        "Property"
-      ],
+      "@type": ["Voltage", "Property"],
       "displayName": {
         "en": "maximum voltage rating"
       },
@@ -38,10 +35,7 @@
       "writable": true
     },
     {
-      "@type": [
-        "Current",
-        "Property"
-      ],
+      "@type": ["Current", "Property"],
       "displayName": {
         "en": "minimum current rating"
       },
@@ -51,10 +45,7 @@
       "writable": true
     },
     {
-      "@type": [
-        "Voltage",
-        "Property"
-      ],
+      "@type": ["Voltage", "Property"],
       "displayName": {
         "en": "maximum voltage rating"
       },
@@ -64,10 +55,7 @@
       "writable": true
     },
     {
-      "@type": [
-        "Current",
-        "Property"
-      ],
+      "@type": ["Current", "Property"],
       "displayName": {
         "en": "maximum current rating"
       },

--- a/Ontology/Asset/Equipment/Meter/GasMeter.json
+++ b/Ontology/Asset/Equipment/Meter/GasMeter.json
@@ -12,48 +12,108 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "Temperature"],
       "displayName": {
         "en": "minimum temperature rating"
       },
       "name": "minTemperatureRating",
       "schema": "double",
+      "unit": "degreeCelsius",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "minimum temperature rating unit"
+      },
+      "name": "minTemperatureRatingUnit",
+      "annotates": "minTemperatureRating",
+      "overrides": "unit",
+      "schema": "TemperatureUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "MassFlowRate"],
       "displayName": {
         "en": "minimum mass flow rating"
       },
       "name": "minMassFlowRating",
       "schema": "double",
+      "unit": "kilogramPerHour",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "minimum mass flow rating unit"
+      },
+      "name": "minMassFlowRatingUnit",
+      "annotates": "minMassFlowRating",
+      "overrides": "unit",
+      "schema": "MassFlowRateUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Temperature"],
       "displayName": {
         "en": "maximum temperature rating"
       },
       "name": "maxTemperatureRating",
       "schema": "double",
+      "unit": "degreeCelsius",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "maximum temperature rating unit"
+      },
+      "name": "maxTemperatureRatingUnit",
+      "annotates": "maxTemperatureRating",
+      "overrides": "unit",
+      "schema": "TemperatureUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Pressure"],
       "displayName": {
         "en": "maximum pressure rating"
       },
       "name": "maxPressureRating",
       "schema": "double",
+      "unit": "bar",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "maximum pressure rating unit"
+      },
+      "name": "maxPressureRatingUnit",
+      "annotates": "maxPressureRating",
+      "overrides": "unit",
+      "schema": "PressureUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "MassFlowRate"],
       "displayName": {
         "en": "maximum mass flow rating"
       },
       "name": "maxMassFlowRating",
       "schema": "double",
+      "unit": "kilogramPerHour",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "maximum mass flow rating unit"
+      },
+      "name": "maxMassFlowRatingUnit",
+      "annotates": "maxMassFlowRating",
+      "overrides": "unit",
+      "schema": "MassFlowRateUnit",
       "writable": true
     },
     {
@@ -77,6 +137,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Meter;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Equipment/Meter/GasMeter.json
+++ b/Ontology/Asset/Equipment/Meter/GasMeter.json
@@ -138,6 +138,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Meter;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/Meter/ThermalMeter.json
+++ b/Ontology/Asset/Equipment/Meter/ThermalMeter.json
@@ -12,48 +12,108 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "VolumeFlowRate"],
       "displayName": {
         "en": "minimum volume flow rating"
       },
       "name": "minVolumeFlowRating",
       "schema": "double",
+      "unit": "litrePerSecond",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "minimum volume flow rating unit"
+      },
+      "name": "minVolumeFlowRatingUnit",
+      "annotates": "minVolumeFlowRating",
+      "overrides": "unit",
+      "schema": "VolumeFlowRateUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Temperature"],
       "displayName": {
         "en": "minimum temperature rating"
       },
       "name": "minTemperatureRating",
       "schema": "double",
+      "unit": "degreeCelsius",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "minimum temperature rating unit"
+      },
+      "name": "minTemperatureRatingUnit",
+      "annotates": "minTemperatureRating",
+      "overrides": "unit",
+      "schema": "TemperatureUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "VolumeFlowRate"],
       "displayName": {
         "en": "maximum volume flow rating"
       },
       "name": "maxVolumeFlowRating",
       "schema": "double",
+      "unit": "litrePerSecond",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "maximum volume flow rating unit"
+      },
+      "name": "maxVolumeFlowRatingUnit",
+      "annotates": "maxVolumeFlowRating",
+      "overrides": "unit",
+      "schema": "VolumeFlowRateUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Temperature"],
       "displayName": {
         "en": "maximum temperature rating"
       },
       "name": "maxTemperatureRating",
       "schema": "double",
+      "unit": "degreeCelsius",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "maximum temperature rating unit"
+      },
+      "name": "maxTemperatureRatingUnit",
+      "annotates": "maxTemperatureRating",
+      "overrides": "unit",
+      "schema": "TemperatureUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Pressure"],
       "displayName": {
         "en": "maximum pressure rating"
       },
       "name": "maxPressureRating",
       "schema": "double",
+      "unit": "bar",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "maximum pressure rating unit"
+      },
+      "name": "maxPressureRatingUnit",
+      "annotates": "maxPressureRating",
+      "overrides": "unit",
+      "schema": "PressureUnit",
       "writable": true
     },
     {
@@ -77,6 +137,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Meter;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Equipment/Meter/ThermalMeter.json
+++ b/Ontology/Asset/Equipment/Meter/ThermalMeter.json
@@ -138,6 +138,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Meter;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/Meter/WaterMeter.json
+++ b/Ontology/Asset/Equipment/Meter/WaterMeter.json
@@ -12,48 +12,108 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "VolumeFlowRate"],
       "displayName": {
         "en": "minimum volume flow rating"
       },
       "name": "minVolumeFlowRating",
       "schema": "double",
+      "unit": "litrePerSecond",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "minimum volume flow rating unit"
+      },
+      "name": "minVolumeFlowRatingUnit",
+      "annotates": "minVolumeFlowRating",
+      "overrides": "unit",
+      "schema": "VolumeFlowRateUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Temperature"],
       "displayName": {
         "en": "minimum temperature rating"
       },
       "name": "minTemperatureRating",
       "schema": "double",
+      "unit": "degreeCelsius",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "minimum temperature rating unit"
+      },
+      "name": "minTemperatureRatingUnit",
+      "annotates": "minTemperatureRating",
+      "overrides": "unit",
+      "schema": "TemperatureUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "VolumeFlowRate"],
       "displayName": {
         "en": "maximum volume flow rating"
       },
       "name": "maxVolumeFlowRating",
       "schema": "double",
+      "unit": "litrePerSecond",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "maximum volume flow rating unit"
+      },
+      "name": "maxVolumeFlowRatingUnit",
+      "annotates": "maxVolumeFlowRating",
+      "overrides": "unit",
+      "schema": "VolumeFlowRateUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Temperature"],
       "displayName": {
         "en": "maximum temperature rating"
       },
       "name": "maxTemperatureRating",
       "schema": "double",
+      "unit": "degreeCelsius",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "maximum temperature rating unit"
+      },
+      "name": "maxTemperatureRatingUnit",
+      "annotates": "maxTemperatureRating",
+      "overrides": "unit",
+      "schema": "TemperatureUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Pressure"],
       "displayName": {
         "en": "maximum pressure rating"
       },
       "name": "maxPressureRating",
       "schema": "double",
+      "unit": "bar",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "maximum pressure rating unit"
+      },
+      "name": "maxPressureRatingUnit",
+      "annotates": "maxPressureRating",
+      "overrides": "unit",
+      "schema": "PressureUnit",
       "writable": true
     },
     {
@@ -77,6 +137,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Meter;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Equipment/Meter/WaterMeter.json
+++ b/Ontology/Asset/Equipment/Meter/WaterMeter.json
@@ -138,6 +138,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Meter;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/PlumbingEquipment/AirCompressor.json
+++ b/Ontology/Asset/Equipment/PlumbingEquipment/AirCompressor.json
@@ -3,19 +3,28 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "Pressure"],
       "displayName": {
         "en": "working pressure"
       },
       "name": "workingPressure",
       "schema": "double",
+      "unit": "bar",
       "writable": true
     },
     {
-      "@type": [
-        "Power",
-        "Property"
-      ],
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "working pressure unit"
+      },
+      "name": "workingPressureUnit",
+      "annotates": "workingPressure",
+      "overrides": "unit",
+      "schema": "PressureUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Power", "Property"],
       "displayName": {
         "en": "motor power"
       },
@@ -25,12 +34,35 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "motor power unit"
+      },
+      "name": "motorPowerUnit",
+      "annotates": "motorPower",
+      "overrides": "unit",
+      "schema": "PowerUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "VolumeFlowRate"],
       "displayName": {
         "en": "free air delivery"
       },
       "name": "freeAirDelivery",
       "schema": "double",
+      "unit": "litrePerSecond",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "free air delivery unit"
+      },
+      "name": "freeAirDeliveryUnit",
+      "annotates": "freeAirDelivery",
+      "overrides": "unit",
+      "schema": "VolumeFlowRateUnit",
       "writable": true
     }
   ],

--- a/Ontology/Asset/Equipment/PlumbingEquipment/AirCompressor.json
+++ b/Ontology/Asset/Equipment/PlumbingEquipment/AirCompressor.json
@@ -72,6 +72,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:PlumbingEquipment;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/PlumbingEquipment/Boiler.json
+++ b/Ontology/Asset/Equipment/PlumbingEquipment/Boiler.json
@@ -129,6 +129,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:PlumbingEquipment;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/PlumbingEquipment/Boiler.json
+++ b/Ontology/Asset/Equipment/PlumbingEquipment/Boiler.json
@@ -25,34 +25,66 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "Volume"],
       "displayName": {
         "en": "tank capacity"
       },
       "name": "tankCapacity",
       "schema": "double",
+      "unit": "litre",
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "tank capacity unit"
+      },
+      "name": "tankCapacityUnit",
+      "annotates": "tankCapacity",
+      "overrides": "unit",
+      "schema": "VolumeUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Power", "Property"],
       "displayName": {
         "en": "power output"
       },
       "name": "powerOutput",
       "schema": "double",
+      "unit": "watt",
       "writable": true
     },
     {
-      "@type": [
-        "Power",
-        "Property"
-      ],
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "power output unit"
+      },
+      "name": "powerOutputUnit",
+      "annotates": "powerOutput",
+      "overrides": "unit",
+      "schema": "PowerUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Power", "Property"],
       "displayName": {
         "en": "power input"
       },
       "name": "powerInput",
       "schema": "double",
       "unit": "watt",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "power input unit"
+      },
+      "name": "powerInputUnit",
+      "annotates": "powerInput",
+      "overrides": "unit",
+      "schema": "PowerUnit",
       "writable": true
     },
     {
@@ -78,7 +110,7 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "VolumeFlowRate"],
       "description": {
         "en": "Imperial measure for the recovery rate of a boiler (gallons per hour)."
       },
@@ -87,6 +119,7 @@
       },
       "name": "recovery100FRise",
       "schema": "integer",
+      "unit": "gallonPerHour",
       "writable": true
     }
   ],

--- a/Ontology/Asset/Equipment/PlumbingEquipment/PlumbingFixture/Faucet.json
+++ b/Ontology/Asset/Equipment/PlumbingEquipment/PlumbingFixture/Faucet.json
@@ -25,12 +25,24 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "VolumeFlowRate"],
       "displayName": {
         "en": "maximum flow rate"
       },
       "name": "maxFlowRate",
       "schema": "double",
+      "unit": "litrePerSecond",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "maximum flow rate unit"
+      },
+      "name": "maxFlowRateUnit",
+      "annotates": "maxFlowRate",
+      "overrides": "unit",
+      "schema": "VolumeFlowRateUnit",
       "writable": true
     },
     {
@@ -56,6 +68,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:PlumbingFixture;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Equipment/PlumbingEquipment/PlumbingFixture/Faucet.json
+++ b/Ontology/Asset/Equipment/PlumbingEquipment/PlumbingFixture/Faucet.json
@@ -69,6 +69,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:PlumbingFixture;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/PlumbingEquipment/PlumbingFixture/FlushometerValve.json
+++ b/Ontology/Asset/Equipment/PlumbingEquipment/PlumbingFixture/FlushometerValve.json
@@ -3,12 +3,24 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "Volume"],
       "displayName": {
         "en": "water per flush"
       },
       "name": "waterPerFlush",
       "schema": "double",
+      "unit": "litre",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "water per flush unit"
+      },
+      "name": "waterPerFlushUnit",
+      "annotates": "waterPerFlush",
+      "overrides": "unit",
+      "schema": "VolumeFlowRateUnit",
       "writable": true
     },
     {
@@ -68,6 +80,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:PlumbingFixture;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Equipment/PlumbingEquipment/PlumbingFixture/FlushometerValve.json
+++ b/Ontology/Asset/Equipment/PlumbingEquipment/PlumbingFixture/FlushometerValve.json
@@ -81,6 +81,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:PlumbingFixture;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/PlumbingEquipment/PlumbingFixture/Toilet/Toilet.json
+++ b/Ontology/Asset/Equipment/PlumbingEquipment/PlumbingFixture/Toilet/Toilet.json
@@ -3,12 +3,24 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "Volume"],
       "displayName": {
         "en": "water per flush"
       },
       "name": "waterPerFlush",
       "schema": "double",
+      "unit": "litre",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "water per flush unit"
+      },
+      "name": "waterPerFlushUnit",
+      "annotates": "waterPerFlush",
+      "overrides": "unit",
+      "schema": "VolumeFlowRateUnit",
       "writable": true
     },
     {
@@ -39,6 +51,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:PlumbingFixture;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Equipment/PlumbingEquipment/PlumbingFixture/Toilet/Toilet.json
+++ b/Ontology/Asset/Equipment/PlumbingEquipment/PlumbingFixture/Toilet/Toilet.json
@@ -52,6 +52,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:PlumbingFixture;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/PlumbingEquipment/PlumbingFixture/Urinal/UrinalFlushometer.json
+++ b/Ontology/Asset/Equipment/PlumbingEquipment/PlumbingFixture/Urinal/UrinalFlushometer.json
@@ -3,12 +3,24 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "Volume"],
       "displayName": {
         "en": "water per flush"
       },
       "name": "waterPerFlush",
       "schema": "double",
+      "unit": "litre",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "water per flush unit"
+      },
+      "name": "waterPerFlushUnit",
+      "annotates": "waterPerFlush",
+      "overrides": "unit",
+      "schema": "VolumeFlowRateUnit",
       "writable": true
     }
   ],
@@ -17,6 +29,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Urinal;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Equipment/PlumbingEquipment/PlumbingFixture/Urinal/UrinalFlushometer.json
+++ b/Ontology/Asset/Equipment/PlumbingEquipment/PlumbingFixture/Urinal/UrinalFlushometer.json
@@ -30,6 +30,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:Urinal;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/PlumbingEquipment/WaterHeater/TankWaterHeater/ElectricTankWaterHeater.json
+++ b/Ontology/Asset/Equipment/PlumbingEquipment/WaterHeater/TankWaterHeater/ElectricTankWaterHeater.json
@@ -30,6 +30,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:TankWaterHeater;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/PlumbingEquipment/WaterHeater/TankWaterHeater/ElectricTankWaterHeater.json
+++ b/Ontology/Asset/Equipment/PlumbingEquipment/WaterHeater/TankWaterHeater/ElectricTankWaterHeater.json
@@ -3,16 +3,24 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": [
-        "Power",
-        "Property"
-      ],
+      "@type": ["Power", "Property"],
       "displayName": {
         "en": "power input"
       },
       "name": "powerInput",
       "schema": "double",
       "unit": "watt",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "power input unit"
+      },
+      "name": "powerInputUnit",
+      "annotates": "powerInput",
+      "overrides": "unit",
+      "schema": "PowerUnit",
       "writable": true
     }
   ],

--- a/Ontology/Asset/Equipment/PlumbingEquipment/WaterHeater/TankWaterHeater/GasTankWaterHeater.json
+++ b/Ontology/Asset/Equipment/PlumbingEquipment/WaterHeater/TankWaterHeater/GasTankWaterHeater.json
@@ -3,12 +3,24 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Power", "Property"],
       "displayName": {
         "en": "power input"
       },
       "name": "powerInput",
       "schema": "double",
+      "unit": "watt",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "power input unit"
+      },
+      "name": "powerInputUnit",
+      "annotates": "powerInput",
+      "overrides": "unit",
+      "schema": "PowerUnit",
       "writable": true
     }
   ],
@@ -17,6 +29,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:TankWaterHeater;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Equipment/PlumbingEquipment/WaterHeater/TankWaterHeater/GasTankWaterHeater.json
+++ b/Ontology/Asset/Equipment/PlumbingEquipment/WaterHeater/TankWaterHeater/GasTankWaterHeater.json
@@ -30,6 +30,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:TankWaterHeater;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/PlumbingEquipment/WaterHeater/TankWaterHeater/TankWaterHeater.json
+++ b/Ontology/Asset/Equipment/PlumbingEquipment/WaterHeater/TankWaterHeater/TankWaterHeater.json
@@ -30,6 +30,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:WaterHeater;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/PlumbingEquipment/WaterHeater/TankWaterHeater/TankWaterHeater.json
+++ b/Ontology/Asset/Equipment/PlumbingEquipment/WaterHeater/TankWaterHeater/TankWaterHeater.json
@@ -3,12 +3,24 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "Volume"],
       "displayName": {
         "en": "tank capacity"
       },
       "name": "tankCapacity",
       "schema": "double",
+      "unit": "litre",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "tank capacity unit"
+      },
+      "name": "tankCapacityUnit",
+      "annotates": "tankCapacity",
+      "overrides": "unit",
+      "schema": "VolumeUnit",
       "writable": true
     }
   ],
@@ -17,6 +29,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:WaterHeater;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Asset/Equipment/PlumbingEquipment/WaterHeater/TanklessWaterHeater/ElectricTanklessWaterHeater.json
+++ b/Ontology/Asset/Equipment/PlumbingEquipment/WaterHeater/TanklessWaterHeater/ElectricTanklessWaterHeater.json
@@ -30,6 +30,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:TanklessWaterHeater;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/PlumbingEquipment/WaterHeater/TanklessWaterHeater/ElectricTanklessWaterHeater.json
+++ b/Ontology/Asset/Equipment/PlumbingEquipment/WaterHeater/TanklessWaterHeater/ElectricTanklessWaterHeater.json
@@ -3,16 +3,24 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": [
-        "Power",
-        "Property"
-      ],
+      "@type": ["Power", "Property"],
       "displayName": {
         "en": "power input"
       },
       "name": "powerInput",
       "schema": "double",
       "unit": "watt",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "power input unit"
+      },
+      "name": "powerInputUnit",
+      "annotates": "powerInput",
+      "overrides": "unit",
+      "schema": "PowerUnit",
       "writable": true
     }
   ],

--- a/Ontology/Asset/Equipment/PlumbingEquipment/WaterHeater/TanklessWaterHeater/GasTanklessWaterHeater.json
+++ b/Ontology/Asset/Equipment/PlumbingEquipment/WaterHeater/TanklessWaterHeater/GasTanklessWaterHeater.json
@@ -30,6 +30,8 @@
   "extends": "dtmi:digitaltwins:rec_3_3:asset:TanklessWaterHeater;1",
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Asset/Equipment/PlumbingEquipment/WaterHeater/TanklessWaterHeater/GasTanklessWaterHeater.json
+++ b/Ontology/Asset/Equipment/PlumbingEquipment/WaterHeater/TanklessWaterHeater/GasTanklessWaterHeater.json
@@ -3,12 +3,24 @@
   "@type": "Interface",
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Power", "Property"],
       "displayName": {
         "en": "power input"
       },
       "name": "powerInput",
       "schema": "double",
+      "unit": "watt",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "power input unit"
+      },
+      "name": "powerInputUnit",
+      "annotates": "powerInput",
+      "overrides": "unit",
+      "schema": "PowerUnit",
       "writable": true
     }
   ],
@@ -17,6 +29,7 @@
   },
   "extends": "dtmi:digitaltwins:rec_3_3:asset:TanklessWaterHeater;1",
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Event/Event.json
+++ b/Ontology/Event/Event.json
@@ -69,7 +69,7 @@
       "writable": true
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "TimeSpan"],
       "description": {
         "en": "Measured in ms (milliseconds). Duration is defined as the length of time that something lasts."
       },
@@ -78,6 +78,7 @@
       },
       "name": "hasDuration",
       "schema": "double",
+      "unit": "millisecond",
       "writable": true
     },
     {
@@ -153,6 +154,7 @@
     "en": "Event"
   },
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Space/Components/SpaceArea.json
+++ b/Ontology/Space/Components/SpaceArea.json
@@ -71,6 +71,8 @@
   ],
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Space/Components/SpaceArea.json
+++ b/Ontology/Space/Components/SpaceArea.json
@@ -6,37 +6,71 @@
   },
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "Area"],
       "name": "grossArea",
       "displayName": {
-        "en": "Gross Area"
+        "en": "gross area"
       },
       "writable": true,
       "schema": "double",
-      "comment": "squareFoot"
+      "unit": "squareMetre"
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "gross area unit"
+      },
+      "name": "grossAreaUnit",
+      "annotates": "grossArea",
+      "overrides": "unit",
+      "schema": "AreaUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Area"],
       "name": "usableArea",
       "displayName": {
-        "en": "Usable Area"
+        "en": "usable area"
       },
       "writable": true,
       "schema": "double",
-      "comment": "squareFoot"
+      "unit": "squareMetre"
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "usable area unit"
+      },
+      "name": "usableAreaUnit",
+      "annotates": "usableArea",
+      "overrides": "unit",
+      "schema": "AreaUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Area"],
       "name": "rentableArea",
       "displayName": {
         "en": "Rentable Area"
       },
       "writable": true,
       "schema": "double",
-      "comment": "squareFoot"
+      "unit": "squareMetre"
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "rentable area unit"
+      },
+      "name": "rentableAreaUnit",
+      "annotates": "rentableArea",
+      "overrides": "unit",
+      "schema": "AreaUnit",
+      "writable": true
     }
   ],
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Space/Components/SpaceCO2.json
+++ b/Ontology/Space/Components/SpaceCO2.json
@@ -6,37 +6,38 @@
   },
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "RelativeDensity"],
       "name": "CO2Sensor",
       "displayName": {
         "en": "CO2 Sensor"
       },
       "writable": true,
       "schema": "double",
-      "comment": "ppm"
+      "unit": "partsPerMillion"
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "RelativeDensity"],
       "name": "CO2Setpoint",
       "displayName": {
         "en": "CO2 Setpoint"
       },
       "writable": true,
       "schema": "double",
-      "comment": "ppm"
+      "unit": "partsPerMillion"
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "RelativeDensity"],
       "name": "CO2Delta",
       "displayName": {
         "en": "CO2 Delta"
       },
       "writable": true,
       "schema": "double",
-      "comment": "ppm"
+      "unit": "partsPerMillion"
     }
   ],
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }

--- a/Ontology/Space/Components/SpaceHumidity.json
+++ b/Ontology/Space/Components/SpaceHumidity.json
@@ -6,10 +6,7 @@
   },
   "contents": [
     {
-      "@type": [
-        "Property",
-        "RelativeHumidity"
-      ],
+      "@type": ["Property", "RelativeHumidity"],
       "name": "humiditySensor",
       "displayName": {
         "en": "Humidity Sensor"
@@ -19,10 +16,7 @@
       "unit": "percent"
     },
     {
-      "@type": [
-        "Property",
-        "RelativeHumidity"
-      ],
+      "@type": ["Property", "RelativeHumidity"],
       "name": "humiditySetpoint",
       "displayName": {
         "en": "Humidity Setpoint"
@@ -32,10 +26,7 @@
       "unit": "percent"
     },
     {
-      "@type": [
-        "Property",
-        "RelativeHumidity"
-      ],
+      "@type": ["Property", "RelativeHumidity"],
       "name": "humidityDelta",
       "displayName": {
         "en": "Humidity Delta"

--- a/Ontology/Space/Components/SpaceOccupancy.json
+++ b/Ontology/Space/Components/SpaceOccupancy.json
@@ -33,10 +33,7 @@
       "schema": "boolean"
     },
     {
-      "@type": [
-        "Property",
-        "TimeSpan"
-      ],
+      "@type": ["Property", "TimeSpan"],
       "name": "dwellTimeAverage",
       "displayName": {
         "en": "Dwell Time Average"
@@ -47,10 +44,7 @@
       "comment": "Average time spent in the space by all individuals in the space"
     },
     {
-      "@type": [
-        "Property",
-        "TimeSpan"
-      ],
+      "@type": ["Property", "TimeSpan"],
       "name": "entranceDwellTime",
       "displayName": {
         "en": "Entrance Dwell Time"
@@ -61,10 +55,7 @@
       "comment": "Wait time to enter the space"
     },
     {
-      "@type": [
-        "Property",
-        "TimeSpan"
-      ],
+      "@type": ["Property", "TimeSpan"],
       "name": "exitDwellTime",
       "displayName": {
         "en": "Exit Dwell Time"

--- a/Ontology/Space/Components/SpaceTemperature.json
+++ b/Ontology/Space/Components/SpaceTemperature.json
@@ -71,6 +71,8 @@
   ],
   "@context": [
     "dtmi:dtdl:context;3",
-    "dtmi:dtdl:extension:quantitativeTypes;1"
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }

--- a/Ontology/Space/Components/SpaceTemperature.json
+++ b/Ontology/Space/Components/SpaceTemperature.json
@@ -6,34 +6,71 @@
   },
   "contents": [
     {
-      "@type": "Property",
+      "@type": ["Property", "Temperature"],
       "name": "temperatureSensor",
       "displayName": {
         "en": "Temperature Sensor"
       },
       "writable": true,
-      "schema": "double"
+      "schema": "double",
+      "unit": "degreeCelsius"
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "temperature sensor unit"
+      },
+      "name": "temperatureSensorUnit",
+      "annotates": "temperatureSensor",
+      "overrides": "unit",
+      "schema": "TemperatureUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Temperature"],
       "name": "temperatureSetpoint",
       "displayName": {
         "en": "Temperature Setpoint"
       },
       "writable": true,
-      "schema": "double"
+      "schema": "double",
+      "unit": "degreeCelsius"
     },
     {
-      "@type": "Property",
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "temperature setpoint unit"
+      },
+      "name": "temperatureSetpointUnit",
+      "annotates": "temperatureSetpoint",
+      "overrides": "unit",
+      "schema": "TemperatureUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Temperature"],
       "name": "temperatureDelta",
       "displayName": {
         "en": "Temperature Delta"
       },
       "writable": true,
-      "schema": "double"
+      "schema": "double",
+      "unit": "degreeCelsius"
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "temperature delta unit"
+      },
+      "name": "temperatureDeltaUnit",
+      "annotates": "temperatureDelta",
+      "overrides": "unit",
+      "schema": "TemperatureUnit",
+      "writable": true
     }
   ],
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1"
   ]
 }


### PR DESCRIPTION
Added quantitative types to properties which should have units using the DTDLv3 annotations and overrides functionality. The additional annotation and override property was added only for the properties which could have variation in the unit. If there is a global standard (i.e. electrical current=ampere) and no anticipated variation, no additional property was added.

This PR adds quantitative types for all DTDL models except the Capabilities which can be addressed in a future PR.